### PR TITLE
Fetch all messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The subcommands are as follows:
   to do this once.
 * `fetch`: Using the saved API credentials in `hinge_creds.json`,
   fetch your messages and store them in `conversations.json`.
+* `messages`: Same as `fetch`, but it gets all the messages instead of
+  just the most recent one.
 * `inbox`: Display your most recent messages from the data in
   `conversations.json`, using a human-readable format.
 * `notify`: Check the data in `conversations.json` and send

--- a/conversations.py
+++ b/conversations.py
@@ -8,7 +8,7 @@ import websocket
 from squeaky_hinge_config import *
 
 
-def fetch_conversations():
+def fetch_conversations(include_messages):
     logging.info(f"START inbox flow")
 
     with open("hinge_creds.json") as f:
@@ -100,8 +100,9 @@ def fetch_conversations():
 
     conversations = resp.json()
 
-    for channel in conversations['channels']:
-        channel['messages'] = fetch_messages(sendbird_session_key, channel)
+    if include_messages:
+        for channel in conversations['channels']:
+            channel['messages'] = fetch_messages(sendbird_session_key, channel)
 
     with open("conversations.json", "w") as f:
         json.dump(conversations, f, indent=2)

--- a/recaptcha.py
+++ b/recaptcha.py
@@ -3,10 +3,8 @@ import webbrowser
 
 import flask
 
-
-def get_token(site_key):
+def run_app(q):
     app = flask.Flask(__name__)
-    q = multiprocessing.Queue(maxsize=1)
 
     @app.route("/")
     def route_index():
@@ -21,8 +19,14 @@ def get_token(site_key):
     _ = route_index
     _ = route_token
 
+    app.run(host="127.0.0.1", port=8888)
+
+
+def get_token(site_key):
+    q = multiprocessing.Queue(maxsize=1)
+
     server = multiprocessing.Process(
-        target=lambda: app.run(host="127.0.0.1", port=8888), daemon=True
+        target=run_app(q), daemon=True
     )
     server.start()
     webbrowser.open(f"http://localhost:8888#{site_key}")

--- a/squeaky_hinge.py
+++ b/squeaky_hinge.py
@@ -22,8 +22,13 @@ def do_login(args):
 
 
 def do_fetch(args):
-    conversations.fetch_conversations()
+    conversations.fetch_conversations(include_messages=False)
     print("Successfully fetched conversations")
+
+
+def do_messages(args):
+    conversations.fetch_conversations(include_messages=True)
+    print("Successfully fetched conversations and messages")
 
 
 def do_inbox(args):
@@ -45,6 +50,8 @@ subparser_login.set_defaults(func=do_login)
 subparser_login.add_argument("phone_number", type=str)
 subparser_fetch = subparsers.add_parser("fetch")
 subparser_fetch.set_defaults(func=do_fetch)
+subparser_fetch = subparsers.add_parser("messages")
+subparser_fetch.set_defaults(func=do_messages)
 subparser_inbox = subparsers.add_parser("inbox")
 subparser_inbox.set_defaults(func=do_inbox)
 subparser_notify = subparsers.add_parser("notify")


### PR DESCRIPTION
Thanks for putting this repo together. I stumbled upon it while trying to find out how to download Hinge messages. 

I've never written python before, but I put together a method to fetch all the messages for a conversation/channel ([API](https://sendbird.com/docs/chat/v3/platform-api/message/messaging-basics/list-messages)). That doesn't seem to be the goal of this project, but maybe it would be a welcome addition. I added the functionality in a new `messages` command.

I got an error on my machine, `AttributeError: Can't pickle local object 'get_token.<locals>.<lambda>'`. I assumed that I was missing some configuration to get it working with the lambda, but it was a quick fix to adjust `recaptcha.py` to move the lambda into a function.